### PR TITLE
Fix remote code execution #1

### DIFF
--- a/snipe/snipe.php
+++ b/snipe/snipe.php
@@ -1,8 +1,8 @@
 <?php
 if(isset($_POST["id"]) && isset($_POST["url"]))
 {
-	$theid = $_POST["id"];
-	$theurl = $_POST["url"];
+	$theid = escapeshellarg($_POST["id"]);
+	$theurl = escapeshellarg($_POST["url"]);
 	$cmd = 'python cgi-bin/vpsnipe.py '. $theurl . " " . $theid;
 	$results = shell_exec($cmd);
 	echo "Snipping File <br />";


### PR DESCRIPTION
Fixes remote code execution caused by passing unsanitized user inputs to shell_exec.

For example, to execute the `id` command, one could do the following: `url=;id` or `id=;id` or similar.